### PR TITLE
Danger base branch

### DIFF
--- a/bin/build-dist.sh
+++ b/bin/build-dist.sh
@@ -17,3 +17,6 @@ yarn build:tsc
 echo "- Copying static files to 'dist/'…"
 cp package.json dist/
 cp readme.md dist/
+
+echo "- Copying bin files to 'dist/'…"
+cp -R src/bin/ dist/bin/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lintervention",
-  "version": "1.1.0-beta.1",
+  "version": "1.1.0",
   "license": "MIT",
   "description": "A tool for identifying ESLint rules you routinely ignore",
   "repository": "github:kapowaz/lintervention",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lintervention",
-  "version": "1.0.0",
+  "version": "1.1.0-beta.1",
   "license": "MIT",
   "description": "A tool for identifying ESLint rules you routinely ignore",
   "repository": "github:kapowaz/lintervention",

--- a/package.json
+++ b/package.json
@@ -15,15 +15,16 @@
     "test": "NODE_ENV=test jest",
     "test:watch": "NODE_ENV=test jest --watch",
     "lint": "eslint --ext .js,.ts src/",
-    "lintervention": "node dist/scripts/example.js",
-    "lintervention:staged": "node dist/scripts/example.js --scope staged",
-    "lintervention:branch": "node dist/scripts/example.js --scope branch",
+    "lintervention": "node dist/bin/lintervention",
+    "lintervention:staged": "yarn lintervention --scope staged",
+    "lintervention:branch": "yarn lintervention --scope branch",
     "typecheck": "tsc --emitDeclarationOnly false --noEmit",
     "build": "sh ./bin/build-dist.sh",
     "build:tsc": "tsc",
     "build:js": "BABEL_ENV='dist-js-build' babel src --extensions '.ts,.js' --out-dir dist --ignore src/index.js,src/**/*.test.js,src/**/*.test.ts,src/test/** --quiet",
     "ci:publish": "sh ./bin/publish.sh"
   },
+  "bin": "./bin/lintervention",
   "dependencies": {
     "minimist": "^1.2.6"
   },

--- a/readme.md
+++ b/readme.md
@@ -77,7 +77,8 @@ import { markdown } from 'danger';
 import { dangerReport } from 'lintervention';
 
 async function lintervention() {
-  const report = await dangerReport();
+  // the default main branch is 'main'; you can override this here.
+  const report = await dangerReport({ baseBranch: 'master' });
   markdown(report);
 }
 

--- a/readme.md
+++ b/readme.md
@@ -49,22 +49,14 @@ There are two (supported) ways to generate reports with Lintervention:
 
 ### yarn or npm script
 
-To use with a yarn or npm script, create a JavaScript file with the following
-contents, called e.g. `lintervention.js`:
-
-```js
-const { report } = require('lintervention');
-
-report();
-```
-
-Then add these scripts to your `package.json`:
+The package installs an `lintervention` tool which you can run with `yarn
+lintervention` or `npx lintervention`. You can optionally also add these scripts
+to your `package.json`:
 
 ```json
 "scripts": {
-  "lintervention": "node path/to/lintervention.js",
-  "lintervention:staged": "node path/to/lintervention.js --scope staged",
-  "lintervention:branch": "node path/to/lintervention.js --scope branch"
+  "lintervention:staged": "lintervention --scope staged",
+  "lintervention:branch": "lintervention --scope branch"
 }
 ```
 

--- a/src/bin/lintervention
+++ b/src/bin/lintervention
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+/* eslint-disable @typescript-eslint/no-var-requires */
+const { report } = require('../scripts/lintervention');
+
+report();

--- a/src/findDisabled.test.ts
+++ b/src/findDisabled.test.ts
@@ -29,7 +29,7 @@ const platform: GrepPlatform =
   (process.env.GREP_PLATFORM as GrepPlatform) || GrepPlatform.BSD;
 
 // This is kind of ridiculous
-const indent = platform === GrepPlatform.BSD ? '    ' : '      ';
+const indent = platform === GrepPlatform.BSD ? '   ' : '      ';
 
 describe('findDisabled', () => {
   it('should correctly identify all eslint disable directives in the repo', async () => {

--- a/src/reportDisabled.ts
+++ b/src/reportDisabled.ts
@@ -21,13 +21,15 @@ export const reportDisabled = async ({
   platform = GrepPlatform.Linux,
   scope = GitScope.Branch,
   files = '',
+  baseBranch,
 }: {
   platform?: GrepPlatform;
   scope?: GitScope;
   files?: string;
+  baseBranch?: string;
 }): Promise<IOverruleReport[]> => {
   const findCommand =
-    scope === GitScope.All ? files : gitFilesCommand({ scope });
+    scope === GitScope.All ? files : gitFilesCommand({ scope, baseBranch });
   const { stdout } = await findDisabled({ platform, findCommand });
   const trimmed = stdout.trim();
 

--- a/src/scripts/danger.ts
+++ b/src/scripts/danger.ts
@@ -15,8 +15,8 @@ const table = ({
 ${rows.map((row) => `|${row.join('|')}|`).join('\n')}
 `;
 
-export const dangerReport = async () => {
-  const directives = await reportDisabled({});
+export const dangerReport = async ({ baseBranch }: { baseBranch?: string }) => {
+  const directives = await reportDisabled({ baseBranch });
   const heading = 'Lintervention Report';
   const headings = ['Count', 'Rule'];
 

--- a/src/scripts/example.ts
+++ b/src/scripts/example.ts
@@ -1,3 +1,0 @@
-import { report } from './lintervention';
-
-report();


### PR DESCRIPTION
This PR makes a couple of changes:

* Exposes the `baseBranch` argument on the `dangerReport` function. This is necessary if you want CI to report on the changes between your PR and a different base branch to `main` (e.g. `master`).
* Adds an `lintervention` binary exposed by the package to be run with `npx`/`yarn`