### PR TITLE
Sort report results

### DIFF
--- a/src/findDisabled.test.ts
+++ b/src/findDisabled.test.ts
@@ -35,13 +35,13 @@ describe('findDisabled', () => {
   it('should correctly identify all eslint disable directives in the repo', async () => {
     const { stdout } = await findDisabled({ platform });
 
-    expect(stdout).toBe(`${indent}3 no-console
+    expect(stdout).toBe(`${indent}5 no-console
+${indent}2 import/no-extraneous-dependencies
 ${indent}1 @typescript-eslint/no-var-requires
 ${indent}1 @typescript-eslint/no-unused-vars
 ${indent}1 @typescript-eslint/no-non-null-assertion
 ${indent}1 no-undef
 ${indent}1 no-param-reassign
-${indent}1 import/no-extraneous-dependencies
 `);
   });
 });

--- a/src/reportDisabled.test.ts
+++ b/src/reportDisabled.test.ts
@@ -18,26 +18,28 @@ describe('reportDisabled', () => {
       scope: GitScope.All,
       files: 'ls -1d src/test/sample/*',
     });
+
     expect(result).toEqual([
-      { count: '1', rule: '@typescript-eslint/no-unused-vars' },
+      { count: '3', rule: 'no-console' },
+      { count: '2', rule: 'import/no-extraneous-dependencies' },
       { count: '1', rule: '@typescript-eslint/no-non-null-assertion' },
-      { count: '1', rule: 'no-undef' },
+      { count: '1', rule: '@typescript-eslint/no-unused-vars' },
       { count: '1', rule: 'no-param-reassign' },
-      { count: '1', rule: 'no-console' },
-      { count: '1', rule: 'import/no-extraneous-dependencies' },
+      { count: '1', rule: 'no-undef' },
     ]);
   });
 
   it('should return a structured report of disabled directives for the entire repo', async () => {
     const result = await reportDisabled({ platform, scope: GitScope.All });
+
     expect(result).toEqual([
-      { count: '3', rule: 'no-console' },
-      { count: '1', rule: '@typescript-eslint/no-var-requires' },
-      { count: '1', rule: '@typescript-eslint/no-unused-vars' },
+      { count: '5', rule: 'no-console' },
+      { count: '2', rule: 'import/no-extraneous-dependencies' },
       { count: '1', rule: '@typescript-eslint/no-non-null-assertion' },
-      { count: '1', rule: 'no-undef' },
+      { count: '1', rule: '@typescript-eslint/no-unused-vars' },
+      { count: '1', rule: '@typescript-eslint/no-var-requires' },
       { count: '1', rule: 'no-param-reassign' },
-      { count: '1', rule: 'import/no-extraneous-dependencies' },
+      { count: '1', rule: 'no-undef' },
     ]);
   });
 });

--- a/src/reportDisabled.ts
+++ b/src/reportDisabled.ts
@@ -1,5 +1,6 @@
 import { findDisabled } from './findDisabled';
 import { gitFilesCommand } from './gitFilesCommand';
+import { sortResults } from './sortResults';
 import { GitScope, GrepPlatform, IOverruleReport } from './types';
 
 /**
@@ -35,9 +36,11 @@ export const reportDisabled = async ({
 
   if (trimmed === '') return [];
 
-  return trimmed.split('\n').map((line) => {
+  const results = trimmed.split('\n').map((line) => {
     const [count, rule] = line.trim().split(' ');
 
     return { count, rule };
   });
+
+  return sortResults(results);
 };

--- a/src/sortResults.test.ts
+++ b/src/sortResults.test.ts
@@ -1,0 +1,25 @@
+import { sortResults } from './sortResults';
+
+const unsorted = [
+  { count: '2', rule: 'import/no-extraneous-dependencies' },
+  { count: '1', rule: 'no-param-reassign' },
+  { count: '1', rule: '@typescript-eslint/no-non-null-assertion' },
+  { count: '3', rule: 'no-console' },
+  { count: '1', rule: '@typescript-eslint/no-unused-vars' },
+  { count: '1', rule: 'no-undef' },
+];
+
+describe('sortResults', () => {
+  it('should sort results according to occurrence and then alphabetically by rule name', () => {
+    const result = sortResults(unsorted);
+
+    expect(result).toEqual([
+      { count: '3', rule: 'no-console' },
+      { count: '2', rule: 'import/no-extraneous-dependencies' },
+      { count: '1', rule: '@typescript-eslint/no-non-null-assertion' },
+      { count: '1', rule: '@typescript-eslint/no-unused-vars' },
+      { count: '1', rule: 'no-param-reassign' },
+      { count: '1', rule: 'no-undef' },
+    ]);
+  });
+});

--- a/src/sortResults.ts
+++ b/src/sortResults.ts
@@ -1,0 +1,20 @@
+import { IOverruleReport } from './types';
+
+/**
+ * Since we can’t reliably expect the sort command to work on all platforms,
+ * it’s easier to just take the output and perform the sorting once we’ve
+ * processed it on this end. This function sorts the results first by number of
+ * occurrences, and then by the rule name alphabetically.
+ */
+export const sortResults = (results: IOverruleReport[]): IOverruleReport[] => {
+  return results.sort((a: IOverruleReport, b: IOverruleReport) => {
+    switch (true) {
+      case a.count > b.count:
+        return -1;
+      case a.count < b.count:
+        return 1;
+      default:
+        return a.rule.localeCompare(b.rule);
+    }
+  });
+};

--- a/src/test/sample/another-no-console.js
+++ b/src/test/sample/another-no-console.js
@@ -1,0 +1,1 @@
+/* eslint-disable no-console */

--- a/src/test/sample/no-console.js
+++ b/src/test/sample/no-console.js
@@ -1,0 +1,1 @@
+/* eslint-disable no-console */

--- a/src/test/sample/no-extraneous-dependencies.js
+++ b/src/test/sample/no-extraneous-dependencies.js
@@ -1,0 +1,1 @@
+/* eslint-disable import/no-extraneous-dependencies */


### PR DESCRIPTION
Right now platform-specific usage might mean the `sort -dr` at the end of the command to find ignored directives doesn't actually sort the results properly, leading to malformatted output. To resolve this, this PR explicitly sorts the results, first by number of occurrences, then by rule name, alphabetically.