### PR TITLE
Refactor main code path structure

### DIFF
--- a/src/findDisabled.test.ts
+++ b/src/findDisabled.test.ts
@@ -1,21 +1,5 @@
 import { GrepPlatform } from './types';
-import { findDisabled, grepDisabledCommand } from '.';
-
-describe('grepDisabledCommand', () => {
-  it('should return the default command', () => {
-    const result = grepDisabledCommand();
-    expect(result).toBe(
-      `grep -rohE --exclude-dir=dist --exclude-dir=node_modules --exclude-dir=.jest-cache --include \\*.jsx --include \\*.js --include \\*.ts --include \\*.tsx \"(?:eslint-disable(?:(?:-next)?-line)?) (@?[-a-z0-9\\/]+(,\\s?@?[-a-z0-9\\/]+)*)\" | sed -E 's/eslint-disable|eslint-disable-line|eslint-disable-next-line//g' | tr ',' '\\n' | tr -d ' ' | sort -d | uniq -c | sort -dr`
-    );
-  });
-
-  it('should return the command with the correct arguments for GNU/Linux grep', () => {
-    const result = grepDisabledCommand({ platform: GrepPlatform.Linux });
-    expect(result).toBe(
-      `grep -rohP --exclude-dir=dist --exclude-dir=node_modules --exclude-dir=.jest-cache --include \\*.jsx --include \\*.js --include \\*.ts --include \\*.tsx \"(?:eslint-disable(?:(?:-next)?-line)?) (@?[-a-z0-9\\/]+(,\\s?@?[-a-z0-9\\/]+)*)\" | sed -E 's/eslint-disable|eslint-disable-line|eslint-disable-next-line//g' | tr ',' '\\n' | tr -d ' ' | sort -d | uniq -c | sort -dr`
-    );
-  });
-});
+import { findDisabled } from '.';
 
 /**
  * In order for these tests to pass in CI, the env variable GREP_PLATFORM needs

--- a/src/findDisabled.ts
+++ b/src/findDisabled.ts
@@ -2,6 +2,7 @@
 import { exec as execChildProcess } from 'child_process';
 import util from 'util';
 
+import { grepCommand } from './grepCommand';
 import { GrepPlatform, IFindDisabled, IOutput } from './types';
 
 const exec = util.promisify(execChildProcess);
@@ -24,7 +25,7 @@ export const findDisabled = async ({
   summary,
   findCommand,
 }: IFindDisabled = DEFAULT_ARGUMENTS): Promise<IOutput> => {
-  const command = grepDisabledCommand({
+  const command = grepCommand({
     platform,
     grepArguments,
     summary,
@@ -32,89 +33,4 @@ export const findDisabled = async ({
   });
 
   return exec(command);
-};
-
-/**
- * `findDisabled` executes a grep command against either all files in
- * the repository, or a subset (based on git history), and returns a promise
- * which when resolved will contain stdout and stderr for the result of
- * executing the command.
- */
-
-export const grepDisabledCommand = ({
-  /**
-   * In CI we want to ensure we default to a GNU/Linux-like set of command-line
-   * utilities; we can override this by passing the --platform argument in from
-   * the command line when running the yarn script locally, otherwise by default
-   * the yarn script will pass --platform bsd, since MacOS uses BSD-like command
-   * line utilities.
-   */
-  platform,
-  grepArguments = DEFAULT_ARGUMENTS.grepArguments,
-  summary = DEFAULT_ARGUMENTS.summary,
-
-  /**
-   * If provided, this command will be prepended to the grep command run, using
-   * xargs to pipe the resulting list of files to search across
-   */
-  findCommand = DEFAULT_ARGUMENTS.findCommand,
-}: IFindDisabled = DEFAULT_ARGUMENTS): string => {
-  /**
-   * This variable lets us specify which files to explicitly include and
-   * include, if we’re not supplying an explicit *list* of files to check; this
-   * is only used when grepping across the entire repo, as opposed to only
-   * checking staged files, or files changed within the current branch.
-   */
-  const excludeDirs = ['dist', 'node_modules', '.jest-cache']
-    .map((dir) => `--exclude-dir=${dir}`)
-    .join(' ');
-  const includeFiles = ['jsx', 'js', 'ts', 'tsx']
-    .map((ext) => `--include \\*.${ext}`)
-    .join(' ');
-  const includeExclude = `${excludeDirs} ${includeFiles}`;
-
-  /**
-   * Platform-specific flags to pass to each of the various commands run here.
-   *
-   * Since grep on BSD uses POSIX-compatible regular expressions, and GNU/Linux
-   * uses Perl-compatible regular expressions, we need to provide the correct
-   * platform-specific argument for which type of regular expressions to
-   * interpret the search pattern as.
-   */
-  const platformGrepArguments =
-    platform === GrepPlatform.BSD ? `-${grepArguments}E` : `-${grepArguments}P`;
-  const directivesPattern =
-    '(?:eslint-disable(?:(?:-next)?-line)?) (@?[-a-z0-9\\/]+(,\\s?@?[-a-z0-9\\/]+)*)';
-
-  /**
-   * This somewhat convoluted command executes grep across a set of input files,
-   * looking for eslint disable directives, which can take one of several forms:
-   *
-   * - eslint-disable <directive(s)>
-   * - eslint-disable-line <directive(s)>
-   * - eslint-disable-next-line <directive(s)>
-   *
-   * <directive(s)> then can also appear as either a single entry, or
-   * comma-separated values
-   *
-   * Once the list of disabled directives has been acquired, it is run through a
-   * few other commands to sort and count occurrences, then print a unique list
-   * of directives and occurrence count, sorted by occurrences.
-   */
-  const grepCommand = `grep ${platformGrepArguments} ${includeExclude} "${directivesPattern}"`;
-  const sedCommand = `sed -E 's/eslint-disable|eslint-disable-line|eslint-disable-next-line//g'`;
-  const countUniques = `tr ',' '\\n' | tr -d ' ' | sort -d | uniq -c | sort -dr`;
-  const fullCommand = summary
-    ? `${grepCommand} | ${sedCommand} | ${countUniques}`
-    : grepCommand;
-
-  /**
-   * If we’re checking all files, we can simply run the above-constructed grep
-   * command, but if a findCommand has been supplied, this should be piped into
-   * the grep command using xargs.
-   */
-  const command =
-    findCommand !== '' ? `${findCommand} | xargs ${fullCommand}` : fullCommand;
-
-  return command;
 };

--- a/src/findDisabled.ts
+++ b/src/findDisabled.ts
@@ -2,8 +2,9 @@
 import { exec as execChildProcess } from 'child_process';
 import util from 'util';
 
+import { gitCommand } from './gitCommand';
 import { grepCommand } from './grepCommand';
-import { GrepPlatform, IFindDisabled, IOutput } from './types';
+import { GitScope, GrepPlatform, IFindDisabled, IOutput } from './types';
 
 const exec = util.promisify(execChildProcess);
 
@@ -23,13 +24,15 @@ export const findDisabled = async ({
   platform,
   grepArguments,
   summary,
-  findCommand,
+  xargs,
+  scope = GitScope.All,
+  baseBranch,
 }: IFindDisabled = DEFAULT_ARGUMENTS): Promise<IOutput> => {
   const command = grepCommand({
     platform,
     grepArguments,
     summary,
-    findCommand,
+    xargs: gitCommand({ xargs, scope, baseBranch }),
   });
 
   return exec(command);

--- a/src/gitCommand.test.ts
+++ b/src/gitCommand.test.ts
@@ -1,16 +1,16 @@
 import { GitScope } from './types';
-import { gitFilesCommand } from '.';
+import { gitCommand } from '.';
 
-describe('gitFilesCommand', () => {
+describe('gitCommand', () => {
   it('should return the correct command if scope is branch', () => {
-    const result = gitFilesCommand({ scope: GitScope.Branch });
+    const result = gitCommand({ scope: GitScope.Branch });
     expect(result).toBe(
       `git diff --name-only main...$(git branch | grep '*' | awk '{print $2}')`
     );
   });
 
   it('should return the correct command if a base branch name is supplied', () => {
-    const result = gitFilesCommand({
+    const result = gitCommand({
       scope: GitScope.Branch,
       baseBranch: 'develop',
     });
@@ -20,12 +20,12 @@ describe('gitFilesCommand', () => {
   });
 
   it('should return the correct command if scope is staged', () => {
-    const result = gitFilesCommand({ scope: GitScope.Staged });
+    const result = gitCommand({ scope: GitScope.Staged });
     expect(result).toBe('git diff --name-only --cached');
   });
 
   it('should return nothing if scope is all', () => {
-    const result = gitFilesCommand({ scope: GitScope.All });
+    const result = gitCommand({ scope: GitScope.All });
     expect(result).toBe('');
   });
 });

--- a/src/gitCommand.test.ts
+++ b/src/gitCommand.test.ts
@@ -2,6 +2,14 @@ import { GitScope } from './types';
 import { gitCommand } from '.';
 
 describe('gitCommand', () => {
+  it('should just return the xargs argument if this is provided', () => {
+    const result = gitCommand({
+      scope: GitScope.Branch,
+      xargs: 'ls -1d src/test/sample/*',
+    });
+    expect(result).toBe(`ls -1d src/test/sample/*`);
+  });
+
   it('should return the correct command if scope is branch', () => {
     const result = gitCommand({ scope: GitScope.Branch });
     expect(result).toBe(

--- a/src/gitCommand.ts
+++ b/src/gitCommand.ts
@@ -1,21 +1,24 @@
-import { GitScope } from './types';
+import { GitScope, IGitCommand } from './types';
 
 /**
- * `gitCommand` returns a git command which when executed will return a list
- * of changed files, either in the current branch, or in the currently staged
- * (uncommitted) changes. If scope is anything other than branch or staged, it
+ * `gitCommand` returns a git command which when executed will return a list of
+ * changed files, either in the current branch, or in the currently staged
+ * (uncommitted) changes.
+ *
+ * If an xargs argument indicating a set of files is passed, this is returned
+ * immediately. Otherwise, if scope is anything other than branch or staged, it
  * returns an empty string.
  */
 export const gitCommand = ({
+  xargs = undefined,
   scope = GitScope.Branch,
   baseBranch = 'main',
-}: {
-  scope?: GitScope;
-  baseBranch?: string;
-}) => {
+}: IGitCommand) => {
   const getCurrentBranch = "$(git branch | grep '*' | awk '{print $2}')";
 
   switch (true) {
+    case Boolean(xargs):
+      return xargs;
     case scope === GitScope.Staged:
       return 'git diff --name-only --cached';
     case scope === GitScope.Branch:

--- a/src/gitCommand.ts
+++ b/src/gitCommand.ts
@@ -1,12 +1,12 @@
 import { GitScope } from './types';
 
 /**
- * `gitFilesCommand` returns a git command which when executed will return a list
+ * `gitCommand` returns a git command which when executed will return a list
  * of changed files, either in the current branch, or in the currently staged
  * (uncommitted) changes. If scope is anything other than branch or staged, it
  * returns an empty string.
  */
-export const gitFilesCommand = ({
+export const gitCommand = ({
   scope = GitScope.Branch,
   baseBranch = 'main',
 }: {

--- a/src/grepCommand.test.ts
+++ b/src/grepCommand.test.ts
@@ -1,0 +1,18 @@
+import { GrepPlatform } from './types';
+import { grepCommand } from '.';
+
+describe('grepCommand', () => {
+  it('should return the default command', () => {
+    const result = grepCommand();
+    expect(result).toBe(
+      `grep -rohE --exclude-dir=dist --exclude-dir=node_modules --exclude-dir=.jest-cache --include \\*.jsx --include \\*.js --include \\*.ts --include \\*.tsx \"(?:eslint-disable(?:(?:-next)?-line)?) (@?[-a-z0-9\\/]+(,\\s?@?[-a-z0-9\\/]+)*)\" | sed -E 's/eslint-disable|eslint-disable-line|eslint-disable-next-line//g' | tr ',' '\\n' | tr -d ' ' | sort -d | uniq -c | sort -dr`
+    );
+  });
+
+  it('should return the command with the correct arguments for GNU/Linux grep', () => {
+    const result = grepCommand({ platform: GrepPlatform.Linux });
+    expect(result).toBe(
+      `grep -rohP --exclude-dir=dist --exclude-dir=node_modules --exclude-dir=.jest-cache --include \\*.jsx --include \\*.js --include \\*.ts --include \\*.tsx \"(?:eslint-disable(?:(?:-next)?-line)?) (@?[-a-z0-9\\/]+(,\\s?@?[-a-z0-9\\/]+)*)\" | sed -E 's/eslint-disable|eslint-disable-line|eslint-disable-next-line//g' | tr ',' '\\n' | tr -d ' ' | sort -d | uniq -c | sort -dr`
+    );
+  });
+});

--- a/src/grepCommand.ts
+++ b/src/grepCommand.ts
@@ -1,0 +1,93 @@
+import { GrepPlatform, IFindDisabled } from './types';
+
+const DEFAULT_ARGUMENTS = {
+  platform: GrepPlatform.BSD,
+  grepArguments: 'roh',
+  summary: true,
+  findCommand: '',
+};
+
+/**
+ * `findDisabled` executes a grep command against either all files in
+ * the repository, or a subset (based on git history), and returns a promise
+ * which when resolved will contain stdout and stderr for the result of
+ * executing the command.
+ */
+
+export const grepCommand = ({
+  /**
+   * In CI we want to ensure we default to a GNU/Linux-like set of command-line
+   * utilities; we can override this by passing the --platform argument in from
+   * the command line when running the yarn script locally, otherwise by default
+   * the yarn script will pass --platform bsd, since MacOS uses BSD-like command
+   * line utilities.
+   */
+  platform,
+  grepArguments = DEFAULT_ARGUMENTS.grepArguments,
+  summary = DEFAULT_ARGUMENTS.summary,
+
+  /**
+   * If provided, this command will be prepended to the grep command run, using
+   * xargs to pipe the resulting list of files to search across
+   */
+  findCommand = DEFAULT_ARGUMENTS.findCommand,
+}: IFindDisabled = DEFAULT_ARGUMENTS): string => {
+  /**
+   * This variable lets us specify which files to explicitly include and
+   * include, if we’re not supplying an explicit *list* of files to check; this
+   * is only used when grepping across the entire repo, as opposed to only
+   * checking staged files, or files changed within the current branch.
+   */
+  const excludeDirs = ['dist', 'node_modules', '.jest-cache']
+    .map((dir) => `--exclude-dir=${dir}`)
+    .join(' ');
+  const includeFiles = ['jsx', 'js', 'ts', 'tsx']
+    .map((ext) => `--include \\*.${ext}`)
+    .join(' ');
+  const includeExclude = `${excludeDirs} ${includeFiles}`;
+
+  /**
+   * Platform-specific flags to pass to each of the various commands run here.
+   *
+   * Since grep on BSD uses POSIX-compatible regular expressions, and GNU/Linux
+   * uses Perl-compatible regular expressions, we need to provide the correct
+   * platform-specific argument for which type of regular expressions to
+   * interpret the search pattern as.
+   */
+  const platformGrepArguments =
+    platform === GrepPlatform.BSD ? `-${grepArguments}E` : `-${grepArguments}P`;
+  const directivesPattern =
+    '(?:eslint-disable(?:(?:-next)?-line)?) (@?[-a-z0-9\\/]+(,\\s?@?[-a-z0-9\\/]+)*)';
+
+  /**
+   * This somewhat convoluted command executes grep across a set of input files,
+   * looking for eslint disable directives, which can take one of several forms:
+   *
+   * - eslint-disable <directive(s)>
+   * - eslint-disable-line <directive(s)>
+   * - eslint-disable-next-line <directive(s)>
+   *
+   * <directive(s)> then can also appear as either a single entry, or
+   * comma-separated values
+   *
+   * Once the list of disabled directives has been acquired, it is run through a
+   * few other commands to sort and count occurrences, then print a unique list
+   * of directives and occurrence count, sorted by occurrences.
+   */
+  const grepCommand = `grep ${platformGrepArguments} ${includeExclude} "${directivesPattern}"`;
+  const sedCommand = `sed -E 's/eslint-disable|eslint-disable-line|eslint-disable-next-line//g'`;
+  const countUniques = `tr ',' '\\n' | tr -d ' ' | sort -d | uniq -c | sort -dr`;
+  const fullCommand = summary
+    ? `${grepCommand} | ${sedCommand} | ${countUniques}`
+    : grepCommand;
+
+  /**
+   * If we’re checking all files, we can simply run the above-constructed grep
+   * command, but if a findCommand has been supplied, this should be piped into
+   * the grep command using xargs.
+   */
+  const command =
+    findCommand !== '' ? `${findCommand} | xargs ${fullCommand}` : fullCommand;
+
+  return command;
+};

--- a/src/grepCommand.ts
+++ b/src/grepCommand.ts
@@ -1,10 +1,10 @@
-import { GrepPlatform, IFindDisabled } from './types';
+import { GrepPlatform, IGrepCommand } from './types';
 
 const DEFAULT_ARGUMENTS = {
   platform: GrepPlatform.BSD,
   grepArguments: 'roh',
   summary: true,
-  findCommand: '',
+  xargs: '',
 };
 
 /**
@@ -30,8 +30,8 @@ export const grepCommand = ({
    * If provided, this command will be prepended to the grep command run, using
    * xargs to pipe the resulting list of files to search across
    */
-  findCommand = DEFAULT_ARGUMENTS.findCommand,
-}: IFindDisabled = DEFAULT_ARGUMENTS): string => {
+  xargs = DEFAULT_ARGUMENTS.xargs,
+}: IGrepCommand = DEFAULT_ARGUMENTS): string => {
   /**
    * This variable lets us specify which files to explicitly include and
    * include, if we’re not supplying an explicit *list* of files to check; this
@@ -87,7 +87,7 @@ export const grepCommand = ({
    * the grep command using xargs.
    */
   const command =
-    findCommand !== '' ? `${findCommand} | xargs ${fullCommand}` : fullCommand;
+    xargs !== '' ? `${xargs} | xargs ${fullCommand}` : fullCommand;
 
   return command;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export * from './findDisabled';
-export * from './gitFilesCommand';
+export * from './gitCommand';
 export * from './reportDisabled';
 export * from './scripts';
 export * from './types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from './findDisabled';
 export * from './gitCommand';
+export * from './grepCommand';
 export * from './reportDisabled';
 export * from './scripts';
 export * from './types';

--- a/src/reportDisabled.ts
+++ b/src/reportDisabled.ts
@@ -1,5 +1,4 @@
 import { findDisabled } from './findDisabled';
-import { gitCommand } from './gitCommand';
 import { sortResults } from './sortResults';
 import { GitScope, GrepPlatform, IOverruleReport } from './types';
 
@@ -29,9 +28,14 @@ export const reportDisabled = async ({
   files?: string;
   baseBranch?: string;
 }): Promise<IOverruleReport[]> => {
-  const findCommand =
-    scope === GitScope.All ? files : gitCommand({ scope, baseBranch });
-  const { stdout } = await findDisabled({ platform, findCommand });
+  const xargs = scope === GitScope.All ? files : '';
+
+  const { stdout } = await findDisabled({
+    platform,
+    scope,
+    baseBranch,
+    xargs,
+  });
   const trimmed = stdout.trim();
 
   if (trimmed === '') return [];

--- a/src/reportDisabled.ts
+++ b/src/reportDisabled.ts
@@ -1,5 +1,5 @@
 import { findDisabled } from './findDisabled';
-import { gitFilesCommand } from './gitFilesCommand';
+import { gitCommand } from './gitCommand';
 import { sortResults } from './sortResults';
 import { GitScope, GrepPlatform, IOverruleReport } from './types';
 
@@ -30,7 +30,7 @@ export const reportDisabled = async ({
   baseBranch?: string;
 }): Promise<IOverruleReport[]> => {
   const findCommand =
-    scope === GitScope.All ? files : gitFilesCommand({ scope, baseBranch });
+    scope === GitScope.All ? files : gitCommand({ scope, baseBranch });
   const { stdout } = await findDisabled({ platform, findCommand });
   const trimmed = stdout.trim();
 

--- a/src/scripts/danger.ts
+++ b/src/scripts/danger.ts
@@ -15,7 +15,11 @@ const table = ({
 ${rows.map((row) => `|${row.join('|')}|`).join('\n')}
 `;
 
-export const dangerReport = async ({ baseBranch }: { baseBranch?: string }) => {
+export const dangerReport = async ({
+  baseBranch = 'main',
+}: {
+  baseBranch?: string;
+}) => {
   const directives = await reportDisabled({ baseBranch });
   const heading = 'Lintervention Report';
   const headings = ['Count', 'Rule'];

--- a/src/scripts/lintervention.ts
+++ b/src/scripts/lintervention.ts
@@ -2,7 +2,7 @@
 
 import minimist from 'minimist';
 
-import { findDisabled, gitCommand, IOutput } from '../';
+import { findDisabled, IOutput } from '../';
 
 export const report = async () => {
   const argv = minimist(process.argv.slice(2));
@@ -12,9 +12,7 @@ export const report = async () => {
     ? argv['with-base-branch']
     : undefined;
 
-  const findCommand = gitCommand({ scope, baseBranch });
-
-  findDisabled({ platform, findCommand }).then(({ stdout }: IOutput) => {
+  findDisabled({ platform, scope, baseBranch }).then(({ stdout }: IOutput) => {
     console.log(stdout);
   });
 };

--- a/src/scripts/lintervention.ts
+++ b/src/scripts/lintervention.ts
@@ -2,7 +2,7 @@
 
 import minimist from 'minimist';
 
-import { findDisabled, gitFilesCommand, IOutput } from '../';
+import { findDisabled, gitCommand, IOutput } from '../';
 
 export const report = async () => {
   const argv = minimist(process.argv.slice(2));
@@ -12,7 +12,7 @@ export const report = async () => {
     ? argv['with-base-branch']
     : undefined;
 
-  const findCommand = gitFilesCommand({ scope, baseBranch });
+  const findCommand = gitCommand({ scope, baseBranch });
 
   findDisabled({ platform, findCommand }).then(({ stdout }: IOutput) => {
     console.log(stdout);

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,11 +9,55 @@ export enum GrepPlatform {
   Linux = 'linux',
 }
 
-export interface IFindDisabled {
+export interface IFindDisabled extends IGrepCommand {
+  /**
+   * Indicates the scope of the git command when performing the search against a
+   * git diff; can be one of Staged (only files currently staged but not
+   * committed), Branch (files that have changed in the specified base branch
+   * compared to the current branch), or All, i.e. all files, regardless of git
+   * status
+   */
+  scope?: GitScope;
+
+  /**
+   * When the scope is Branch, this permits overriding the default baseBranch
+   * configuration value of 'main', e.g. if the base branch is called 'master'
+   */
+  baseBranch?: string;
+}
+
+export interface IGitCommand {
+  xargs?: string;
+  scope?: GitScope;
+  baseBranch?: string;
+}
+
+export interface IGrepCommand {
+  /**
+   * Different platforms have different versions of grep whose command
+   * syntax/structure, and output are subtly different; this allows us to
+   * account for these differences when running in different environments, i.e.
+   * MacOS (development) vs Linux (CI)
+   */
   platform: GrepPlatform;
+
+  /**
+   * Along with the platform, this allows providing different arguments to grep
+   * according to the platform
+   */
   grepArguments?: string;
+
+  /**
+   * Boolean indicating if we’re just generating a summary of disabled
+   * directives, or a full report
+   */
   summary?: boolean;
-  findCommand?: string;
+
+  /**
+   * An optional command to pipe into xargs ahead of the command to count
+   * results, for example to specify a specific location to use as the input.
+   */
+  xargs?: string;
 }
 
 export interface IOutput {


### PR DESCRIPTION
I’ve made a few changes to how the code is structured, to hopefully make it easier to work with and test for future enhancements:

* Renamed `gitFilesCommand` to `gitCommand` to reflect that its purpose is to generate a git diff command for listing files changed within a branch
* Added a new explicit mode for `gitCommand` to pass through a command to pipe into `xargs`, and reflected this in the arguments for various other parts of the control flow into this function
* Split `grepDisabledCommand` (and renamed to `grepCommand`) into its own separate file
* Update main `findDisabled` command to accepts arguments for `xargs` (rather than expecting the git command output to be passed in), as well as the `scope` (i.e. branch or whole repository) and `baseBranch` name (for if the base branch isn't called `main`).
* Fixed an issue where if the default `baseBranch` wasn't explicitly passed in at the top level (i.e. in your dangerfile.js), the whole script would blow up