### PR TITLE
Move command line arguments into lintervention bin

### DIFF
--- a/src/bin/lintervention
+++ b/src/bin/lintervention
@@ -1,5 +1,13 @@
 #!/usr/bin/env node
 /* eslint-disable @typescript-eslint/no-var-requires */
+const minimist = require('minimist');
 const { report } = require('../scripts/lintervention');
 
-report();
+const argv = minimist(process.argv.slice(2));
+const scope = argv.scope || 'all';
+const platform = argv.platform || 'bsd';
+const baseBranch = Object.hasOwnProperty.call(argv, 'with-base-branch')
+  ? argv['with-base-branch']
+  : undefined;
+
+report({ scope, platform, baseBranch });

--- a/src/scripts/lintervention.ts
+++ b/src/scripts/lintervention.ts
@@ -1,18 +1,17 @@
 /* eslint-disable no-console */
 
-import minimist from 'minimist';
+import { findDisabled, GitScope, GrepPlatform, IOutput } from '../';
 
-import { findDisabled, IOutput } from '../';
-
-export const report = async () => {
-  const argv = minimist(process.argv.slice(2));
-  const scope = argv.scope || 'all';
-  const platform = argv.platform || 'bsd';
-  const baseBranch = Object.hasOwnProperty.call(argv, 'with-base-branch')
-    ? argv['with-base-branch']
-    : undefined;
-
-  findDisabled({ platform, scope, baseBranch }).then(({ stdout }: IOutput) => {
+export const report = async ({
+  scope = GitScope.All,
+  platform = GrepPlatform.BSD,
+  baseBranch,
+}: {
+  scope?: GitScope;
+  platform?: GrepPlatform;
+  baseBranch: string;
+}) => {
+  findDisabled({ scope, platform, baseBranch }).then(({ stdout }: IOutput) => {
     console.log(stdout);
   });
 };


### PR DESCRIPTION
The (default) command-line arguments to the `lintervention` bin file exposed by the package have moved so they’re populated from `argv` within that bin file, instead of within the `report` function exported by the package, which is intended to be used by Danger.js setups. This means that you can now override the values of the arguments passed to that function, within the scope of any given Dangerfile.